### PR TITLE
feat: :sparkles: add prettier as a direct dependency

### DIFF
--- a/packages/eslint-config-basic/package.json
+++ b/packages/eslint-config-basic/package.json
@@ -41,6 +41,7 @@
         "eslint-plugin-unused-imports": "^2.0.0",
         "eslint-plugin-yml": "^1.5.0",
         "jsonc-eslint-parser": "^2.2.0",
+        "prettier": "^3.0.3",
         "yaml-eslint-parser": "^1.2.0"
     },
     "devDependencies": {

--- a/packages/eslint-config-basic/package.json
+++ b/packages/eslint-config-basic/package.json
@@ -41,7 +41,6 @@
         "eslint-plugin-unused-imports": "^2.0.0",
         "eslint-plugin-yml": "^1.5.0",
         "jsonc-eslint-parser": "^2.2.0",
-        "prettier": "^3.0.3",
         "yaml-eslint-parser": "^1.2.0"
     },
     "devDependencies": {
@@ -49,6 +48,7 @@
         "@semantic-release/commit-analyzer": "^9.0.2",
         "@semantic-release/git": "^9.0.1",
         "eslint": "^8.38.0",
+        "prettier": "^3.0.3",
         "semantic-release": "^20.1.3",
         "semantic-release-monorepo": "^7.0.5",
         "semantic-release-yarn": "^0.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -536,6 +536,7 @@ __metadata:
     eslint-plugin-unused-imports: ^2.0.0
     eslint-plugin-yml: ^1.5.0
     jsonc-eslint-parser: ^2.2.0
+    prettier: ^3.0.3
     semantic-release: ^20.1.3
     semantic-release-monorepo: ^7.0.5
     semantic-release-yarn: ^0.3.2
@@ -5870,6 +5871,15 @@ __metadata:
   bin:
     prettier: bin/prettier.cjs
   checksum: e1f3f16c7fe0495de3faa182597871f74927d787cce3c52095a66ff5d7eacc05173371d5f58bf12141a0a1b6bfe739a338531d6cf18b92c7256c1319f2c84e73
+  languageName: node
+  linkType: hard
+
+"prettier@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "prettier@npm:3.0.3"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: e10b9af02b281f6c617362ebd2571b1d7fc9fb8a3bd17e371754428cda992e5e8d8b7a046e8f7d3e2da1dcd21aa001e2e3c797402ebb6111b5cd19609dd228e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add `prettier` as a dependency of our package, so users won't have to install it themselves, and everything will just work out of the box with `npm install @owowagency/eslint-config-x`