### PR TITLE
Vue: allow reserved component names

### DIFF
--- a/packages/eslint-config-vue/index.js
+++ b/packages/eslint-config-vue/index.js
@@ -18,6 +18,7 @@ module.exports = {
     rules: {
         'vue/html-indent': ['error', 4],
         'vue/multi-word-component-names': 'off',
+        'vue/no-reserved-component-names': 'off',
         'vue/padding-line-between-tags': 'error',
         'vue/component-tags-order': ['error', { order: ['script', 'template', 'style'] }],
     },


### PR DESCRIPTION
We want to allow reserved component names, because we are lazy. They are defined with a Capital letter anyways. (discussed with @thomasowow, fight with him about it if you want)