### PR TITLE
feat: warn on exhaustive deps

### DIFF
--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -11,6 +11,7 @@ module.exports = {
     },
 
     rules: {
+        'react-hooks/exhaustive-deps': 'warn',
         'react/jsx-newline': 'off',
         'react/jsx-wrap-multilines': 'off',
         'react/react-in-jsx-scope': 'off',
@@ -40,9 +41,9 @@ module.exports = {
                 reservedFirst: true,
             },
         ],
+        'react/jsx-equals-spacing': ['error', 'never'],
+        'react/jsx-indent': ['error', 4],
         'react/no-deprecated': ['error'],
         'react/self-closing-comp': 'error',
-        'react/jsx-indent': ['error', 4],
-        'react/jsx-equals-spacing': ['error', 'never'],
     },
 };


### PR DESCRIPTION
react-hooks/exhaustive-deps put on "warn" mode by default (not error)

- generally useful for bug-prone lifecycle
- reports false positives
- urges you to create infinite update cycles with useEffect
- does not understand delicate code logic