### PR TITLE
feat: padding line between statements for multiline expressions

### DIFF
--- a/packages/eslint-config-basic/index.js
+++ b/packages/eslint-config-basic/index.js
@@ -353,11 +353,8 @@ module.exports = {
         // OWOW
         'padding-line-between-statements': [
             'error',
-            {
-                blankLine: 'always',
-                prev: '*',
-                next: ['return', 'export', 'class', 'if', 'for'],
-            },
+            { blankLine: 'always', prev: 'multiline-expression', next: '*' },
+            { blankLine: 'always', prev: '*', next: 'multiline-expression' },
         ],
     },
 };

--- a/packages/eslint-config-basic/index.js
+++ b/packages/eslint-config-basic/index.js
@@ -355,6 +355,12 @@ module.exports = {
             'error',
             { blankLine: 'always', prev: 'multiline-expression', next: '*' },
             { blankLine: 'always', prev: '*', next: 'multiline-expression' },
+            { blankLine: 'always', prev: 'multiline-block-like', next: '*' },
+            { blankLine: 'always', prev: '*', next: 'multiline-block-like' },
+            { blankLine: 'always', prev: 'multiline-const', next: '*' },
+            { blankLine: 'always', prev: '*', next: 'multiline-const' },
+            { blankLine: 'always', prev: 'multiline-let', next: '*' },
+            { blankLine: 'always', prev: '*', next: 'multiline-let' },
         ],
     },
 };


### PR DESCRIPTION
Add padding-line-between-statements
- Only multi-line statements should have empty lines between them, so we can create compact procedures of single line expressions and statements.